### PR TITLE
OPHJOD-1213: Update SpiderDiagram to be more usable with screenreader

### DIFF
--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -1856,7 +1856,8 @@
       "back": "Back"
     },
     "spider": {
-      "title": "Section comparison"
+      "title": "Section comparison",
+      "value": "Value"
     },
     "quick-self-evaluation-summary-section": {
       "more-info": "More information of the topic"

--- a/src/i18n/fi/translation.json
+++ b/src/i18n/fi/translation.json
@@ -2051,7 +2051,8 @@
       "very-much": "Paljon"
     },
     "spider": {
-      "title": "Osioiden vertailu"
+      "title": "Osioiden vertailu",
+      "value": "Arvo"
     },
     "button": {
       "back": "Takaisin"

--- a/src/i18n/sv/translation.json
+++ b/src/i18n/sv/translation.json
@@ -236,7 +236,8 @@
       "no-choice": "Inget val"
     },
     "spider": {
-      "title": "Jämförelse av avsnitt"
+      "title": "Jämförelse av avsnitt",
+      "value": "Värde"
     },
     "quick-self-evaluation-summary-section": {
       "more-info": "Mer information om detta ämne"


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Update SpiderDiagram to be more usable with screenreader

## Notes
- Added a sectionScore to a screenreader user so at least the user can compare which score is higher/lower than other values.
- Modified the SpiderDiagram to use **breakpoint** instead of using **hidden** classname, as those were still in the DOM and causing harms to screenreader users (hiding the labels of the images).
  - Previously it used some weird `@5xl` classname, but now using `md` breakpoint which felt okay for this.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1213
