### PR TITLE
OPHJOD-2291: Update DS and add disclaimer text to chatbot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1459,7 +1459,7 @@
     },
     "node_modules/@jod/design-system": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/Opetushallitus/jod-design-system.git#1a1ae2de3fa62c49636db394bed960397e79c8be",
+      "resolved": "git+ssh://git@github.com/Opetushallitus/jod-design-system.git#8d58538ca3a8187c8e4eca6d0363c994dd77cb48",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ark-ui/react": "^5.18.3",

--- a/src/i18n/fi/translation.json
+++ b/src/i18n/fi/translation.json
@@ -107,6 +107,7 @@
   "chatbot": {
     "agent-name": "Neuvontabotti",
     "error-message": "Tapahtui jokin virhe.",
+    "disclaimer": "Älä syötä henkilötietojasi neuvontabotille.",
     "greeting": "Hei, olen Osaamispolun neuvontabotti. Voin auttaa sinua Osaamispolkuun liittyvissä kysymyksissä.<br/><br/>Olen testiversio ja harjoittelen vielä, joten en osaa vastata kaikkiin kysymyksiin. Kysy silti, sillä opin koko ajan lisää. Esittämäsi kysymykset auttavat minua kehittymään.<br/><br/>Esitäthän yhden kysymyksen kerrallaan. Pidä kysymykset lyhyinä ja selkeinä, niin pystyn auttamaan paremmin. En muista aiempia kysymyksiä tai vastauksia. Ethän kirjoita henkilötietojasi chattiin. Miten voin auttaa?",
     "header": "Neuvontabotti",
     "open-window-text": "Kysy neuvoa?",

--- a/src/routes/Root/Root.tsx
+++ b/src/routes/Root/Root.tsx
@@ -165,6 +165,7 @@ const Root = () => {
         greeting={t('chatbot.greeting')}
         textInputPlaceholder={t('chatbot.text-input-placeholder')}
         waitingmessage={t('chatbot.waiting-message')}
+        disclaimer={t('chatbot.disclaimer')}
       />
       <Footer
         language={language}


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Update DS to apply the following changes
* Updated `NoteStack` logic [OPHJOD-2367](https://jira.eduuni.fi/browse/OPHJOD-2367)
* English KEHA logo in the footer [OPHJOD-2359](https://jira.eduuni.fi/browse/OPHJOD-2359)
* Ability to set a disclaimer text to the chatbot [OPHJOD-2291](https://jira.eduuni.fi/browse/OPHJOD-2291)

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2367
https://jira.eduuni.fi/browse/OPHJOD-2359
https://jira.eduuni.fi/browse/OPHJOD-2291