### PR TITLE
OPHJOD-3121: Update PortalLink to be external link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@headlessui/react": "2.2.9",
         "@hookform/error-message": "2.0.1",
         "@hookform/resolvers": "5.2.2",
-        "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260420-3/jod-design-system-0.0.0.tgz",
+        "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260423-2/jod-design-system-0.0.0.tgz",
         "@react-pdf/renderer": "4.3.2",
         "cva": "1.0.0-beta.4",
         "emoji-datasource-apple": "16.0.0",
@@ -1027,8 +1027,8 @@
     },
     "node_modules/@jod/design-system": {
       "version": "0.0.0",
-      "resolved": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260420-3/jod-design-system-0.0.0.tgz",
-      "integrity": "sha512-k/qzqGt3ywJj7N1CcEKRtrbEk7azN6HkqmFGS+gTHCwzjC7iBzO/lLd+N7E49AsZ9YJuDQhPWRp/Xzto5hu0hg==",
+      "resolved": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260423-2/jod-design-system-0.0.0.tgz",
+      "integrity": "sha512-5uAqjo3EzKn8xruTLd7+NknT99RBFJBJiQodWRoMZy676H/zd9ubS9o9tYZgSgj47bXiGgaBhmvmpL0f0P6bKA==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ark-ui/react": "5.30.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@headlessui/react": "2.2.9",
     "@hookform/error-message": "2.0.1",
     "@hookform/resolvers": "5.2.2",
-    "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260420-3/jod-design-system-0.0.0.tgz",
+    "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260423-2/jod-design-system-0.0.0.tgz",
     "@react-pdf/renderer": "4.3.2",
     "cva": "1.0.0-beta.4",
     "emoji-datasource-apple": "16.0.0",

--- a/src/components/NavMenu/NavMenu.tsx
+++ b/src/components/NavMenu/NavMenu.tsx
@@ -7,13 +7,13 @@ import { useMenuRoutes } from './menuRoutes';
 import { JodCheckmark, JodLink } from '@jod/design-system/icons';
 import toast from 'react-hot-toast/headless';
 
-const PortalLink = ({ children, className }: LinkComponent) => {
+const PortalLink = ({ children, className, rel, target }: LinkComponent) => {
   const {
     i18n: { language },
   } = useTranslation();
 
   return (
-    <a href={`/${language}`} className={className}>
+    <a href={`/${language}`} className={className} rel={rel} target={target}>
       {children}
     </a>
   );


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

- Update `@jod/design-system`
- Update portallink to be external; open in new tab/window


## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3121
