### PR TITLE
OPHJOD-2133: Update color token usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@headlessui/react": "2.2.10",
         "@hookform/error-message": "2.0.1",
         "@hookform/resolvers": "5.4.0",
-        "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260608-2/jod-design-system-0.0.0.tgz",
+        "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260612-1/jod-design-system-0.0.0.tgz",
         "@react-pdf/renderer": "4.5.1",
         "cva": "1.0.0-beta.4",
         "emoji-datasource-apple": "16.0.0",
@@ -1029,8 +1029,8 @@
     },
     "node_modules/@jod/design-system": {
       "version": "0.0.0",
-      "resolved": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260608-2/jod-design-system-0.0.0.tgz",
-      "integrity": "sha512-cetrI/nJusi4GI5mo7OGmywa3wXBOLFltPIA4vFUqSrdhmqBJAXywAowcHHP4XdKnytE0ozLTKKcaD5MTblKDA==",
+      "resolved": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260612-1/jod-design-system-0.0.0.tgz",
+      "integrity": "sha512-QR5I89D2wvaR9bq5p/HS+1iiOILF6S+Az/7oG77TokT5TVhZSgtVpeDI20QrOoAHca4d1JqepXcfgKuYsixozg==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ark-ui/react": "5.36.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@headlessui/react": "2.2.10",
     "@hookform/error-message": "2.0.1",
     "@hookform/resolvers": "5.4.0",
-    "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260608-2/jod-design-system-0.0.0.tgz",
+    "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260612-1/jod-design-system-0.0.0.tgz",
     "@react-pdf/renderer": "4.5.1",
     "cva": "1.0.0-beta.4",
     "emoji-datasource-apple": "16.0.0",

--- a/src/components/FormError/FormError.tsx
+++ b/src/components/FormError/FormError.tsx
@@ -15,5 +15,9 @@ interface FormErrorProps {
  */
 export const FormError = ({ name, errors }: FormErrorProps) =>
   name && getNestedProperty(errors, name) ? (
-    <ErrorMessage name={name} errors={errors} render={({ message }) => <span className="text-alert">{message}</span>} />
+    <ErrorMessage
+      name={name}
+      errors={errors}
+      render={({ message }) => <span className="text-alert-1">{message}</span>}
+    />
   ) : null;

--- a/src/components/IconHeading/index.tsx
+++ b/src/components/IconHeading/index.tsx
@@ -10,8 +10,8 @@ export const IconHeading = ({
   icon,
   title,
   testId,
-  bgClassName = 'bg-secondary-1-dark',
-  textClassName = 'text-secondary-1-dark',
+  bgClassName = 'bg-primary-1-dark',
+  textClassName = 'text-primary-1-dark',
 }: IconHeadingProps) => {
   return (
     <div className="mb-6 flex items-center gap-x-4 sm:mb-8">


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
‼️ **Requires** Opetushallitus/jod-design-system/pull/584

- Update `@jod/design-system`
- Update color tokens usage


<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2133
