### PR TITLE
OPHJOD-2060: Update summary page to have only 1 primary button

### DIFF
--- a/src/features/exercises/components/OpenAllExercisesPDFButton.tsx
+++ b/src/features/exercises/components/OpenAllExercisesPDFButton.tsx
@@ -1,7 +1,8 @@
 import { BlobProvider } from '@react-pdf/renderer';
 import { useTranslation } from 'react-i18next';
 
-import { Button } from '@/components';
+import { Button as DSButton } from '@jod/design-system';
+
 import AllExercisesDocument from '@/features/pdf/documents/AllExercisesDocument';
 import useSkillAreas from '@/hooks/useSkillAreas';
 import { Open } from '@/icons';
@@ -41,33 +42,39 @@ export const OpenAllExercisesPDFButton = ({ hideWhenNoAnswers = false }: { hideW
       return null;
     }
     return (
-      <Button iconSide="left" icon={<Open />} disabled={true} variant="filled">
-        {t('career-management-summary.summary-link-card.no-exercises-done')}
-      </Button>
+      <DSButton
+        iconSide="left"
+        icon={<Open />}
+        disabled={true}
+        variant="gray"
+        label={t('career-management-summary.summary-link-card.no-exercises-done')}
+      />
     );
   }
   return (
     <BlobProvider document={<AllExercisesDocument exerciseAnswers={exerciseAnswers} />}>
       {({ url, loading }) =>
         loading || !url ? (
-          <Button iconSide="left" icon={<Open />} disabled={true} variant="filled">
-            {t('career-management-summary.summary-link-card.link-loading')}
-          </Button>
+          <DSButton
+            iconSide="left"
+            icon={<Open />}
+            disabled={true}
+            variant="gray"
+            label={t('career-management-summary.summary-link-card.link-loading')}
+          />
         ) : (
           <div className="flex">
-            <a
-              href={url}
-              target="_blank"
-              rel="noreferrer"
-              className="group bg-primary font-display hover:bg-primary-hover font-bold relative flex min-h-[44px] items-center justify-center gap-3 rounded-full px-5 py-3 whitespace-nowrap text-white outline-offset-4 hover:underline"
-            >
-              <div className="size-6">
-                <Open />
-              </div>
-              <span className="text-center leading-none text-wrap">
-                {t('career-management-summary.exercise-pdf-card.button')}
-              </span>
-            </a>
+            <DSButton
+              icon={<Open />}
+              iconSide="left"
+              variant="gray"
+              label={t('career-management-summary.exercise-pdf-card.button')}
+              linkComponent={({ children, className }) => (
+                <a href={url} target="_blank" rel="noreferrer" className={className}>
+                  {children}
+                </a>
+              )}
+            />
           </div>
         )
       }

--- a/src/routes/CareerPlanningSummary/CareerPlanningSummary.tsx
+++ b/src/routes/CareerPlanningSummary/CareerPlanningSummary.tsx
@@ -2,6 +2,8 @@ import { BlobProvider } from '@react-pdf/renderer';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { Button as DSButton } from '@jod/design-system';
+
 import { SpiderDiagram, BackButton, Button, Card } from '@/components';
 import { CareerPlanningSummarySection } from '@/components/CareerPlanningSummarySection/CareerPlanningSummarySection';
 import { TotalScoreRecord } from '@/components/SpiderDiagram/SpiderDiagram';
@@ -94,24 +96,26 @@ const CareerPlanningSummary = () => {
           >
             {({ url, loading }) =>
               loading || !url ? (
-                <Button iconSide="left" icon={<Open />} disabled={true} variant="filled">
-                  {t('career-management-summary.summary-link-card.link-loading')}
-                </Button>
+                <DSButton
+                  iconSide="left"
+                  icon={<Open />}
+                  disabled={true}
+                  variant="gray"
+                  label={t('career-management-summary.summary-link-card.link-loading')}
+                />
               ) : (
                 <div className="flex">
-                  <a
-                    href={url}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="group bg-primary font-display hover:bg-primary-hover font-bold relative flex min-h-[44px] items-center justify-center gap-3 rounded-full px-5 py-3 whitespace-nowrap text-white outline-offset-4 hover:underline"
-                  >
-                    <div className="size-6">
-                      <Open />
-                    </div>
-                    <span className="text-center leading-none text-wrap">
-                      {t('career-management-summary.summary-pdf-card.button')}
-                    </span>
-                  </a>
+                  <DSButton
+                    icon={<Open />}
+                    iconSide="left"
+                    variant="gray"
+                    label={t('career-management-summary.summary-pdf-card.button')}
+                    linkComponent={({ children, className }) => (
+                      <a href={url} target="_blank" rel="noreferrer" className={className}>
+                        {children}
+                      </a>
+                    )}
+                  />
                 </div>
               )
             }
@@ -127,18 +131,19 @@ const CareerPlanningSummary = () => {
         <Card>
           <h3 className="mb-2 text-heading-3">{t('career-management-summary.summary-link-card.title')}</h3>
           <p className="mb-6">{t('career-management-summary.summary-link-card.description')}</p>
-          <Button
-            variant="filled"
+          <DSButton
+            variant="gray"
             icon={linkCopied ? <Check /> : <Link />}
             iconSide="left"
             onClick={() => {
               void copyToClipboard();
             }}
-          >
-            {linkCopied
-              ? t('career-management-summary.summary-link-card.link-copied')
-              : t('career-management-summary.summary-link-card.copy-link')}
-          </Button>
+            label={
+              linkCopied
+                ? t('career-management-summary.summary-link-card.link-copied')
+                : t('career-management-summary.summary-link-card.copy-link')
+            }
+          />
         </Card>
       </div>
     </div>


### PR DESCRIPTION
Updated to use the Button component from DS on those parts.

<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

Update summary page to only have one primary button (accent) instead of possibly three of them at the same time.

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2060
